### PR TITLE
Add option to limit number of concurrent tasks.

### DIFF
--- a/ConcurrentCollectionOperations/NSArray+ConcurrentCollectionOperations.h
+++ b/ConcurrentCollectionOperations/NSArray+ConcurrentCollectionOperations.h
@@ -12,7 +12,7 @@
 @interface NSArray (ConcurrentCollectionOperations)
 
 - (instancetype)cco_concurrentMap:(CCOMapBlock)mapBlock;
-- (instancetype)cco_concurrentWithQueue:(dispatch_queue_t)queue map:(CCOMapBlock)mapBlock;
+- (instancetype)cco_concurrentWithQueue:(dispatch_queue_t)queue taskCountLimit:(int)taskCountLimit map:(CCOMapBlock)mapBlock;
 
 - (instancetype)cco_concurrentFilter:(CCOPredicateBlock)predicateBlock;
 - (instancetype)cco_concurrentWithQueue:(dispatch_queue_t)queue filter:(CCOPredicateBlock)predicateBlock;


### PR DESCRIPTION
As I’m in full preparation mode for WWDC, I did not have time to make this into a full fledged patch yet, but I did want to open up discussion on it now.

This current patch limits the number of concurrent tasks to a given number and defaults to twice the number of CPU cores. (Somewhat arbitrary, but likely a good default.)

The reason for this is that GCD will happily spawn as much threads as needed, but it does not take into account other stress on the machine, e.g. memory usage. So if you have a task that takes up a lot of memory per task, your system comes to a grinding halt before it ever finishes.

I’m thinking that it would be nice to be able to set a global default, or if not specified, default to something like twice the CPU cores. It would also be nice to be able to specify that a job does not need to be limited, but it should probably be done per job (not global). I.e. the shorthand methods all check the global default value, whereas the verbose methods /need/ a value, which could be `0` meaning ‘no limit’.
