### PR TITLE
All concurrent operations should return immutable objects

### DIFF
--- a/ConcurrentCollectionOperations/NSArray+ConcurrentCollectionOperations.m
+++ b/ConcurrentCollectionOperations/NSArray+ConcurrentCollectionOperations.m
@@ -53,14 +53,16 @@
         }
     });
 
-    NSMutableArray *result = [NSMutableArray arrayWithCapacity:filteredCount];
+    NSMutableArray *temp = [NSMutableArray arrayWithCapacity:filteredCount];
     for (NSUInteger i = 0; i < self.count; ++i) {
         if (filtered[i] != nil) {
-            [result addObject:filtered[i]];
+            [temp addObject:filtered[i]];
         }
     }
 
     free(filtered);
+    
+    NSArray *result = [NSArray arrayWithArray:temp];
     return result;
 }
 

--- a/ConcurrentCollectionOperations/NSDictionary+ConcurrentCollectionOperations.m
+++ b/ConcurrentCollectionOperations/NSDictionary+ConcurrentCollectionOperations.m
@@ -60,15 +60,17 @@
         }
     });
 
-    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    NSMutableDictionary *temp = [NSMutableDictionary dictionary];
     for (NSUInteger i = 0; i < self.count; ++i) {
         if (objects[i] != nil) {
-            result[keys[i]] = objects[i];
+            temp[keys[i]] = objects[i];
         }
     }
 
     free(objects);
     free(keys);
+    
+    NSDictionary *result = [NSDictionary dictionaryWithDictionary:temp];
     return result;
 }
 

--- a/ConcurrentCollectionOperations/NSSet+ConcurrentCollectionOperations.m
+++ b/ConcurrentCollectionOperations/NSSet+ConcurrentCollectionOperations.m
@@ -58,14 +58,16 @@
         }
     });
 
-    NSMutableSet *result = [NSMutableSet setWithCapacity:filteredCount];
+    NSMutableSet *temp = [NSMutableSet setWithCapacity:filteredCount];
     for (NSUInteger i = 0; i < self.count; ++i) {
         if (filtered[i] != nil) {
-            [result addObject:filtered[i]];
+            [temp addObject:filtered[i]];
         }
     }
 
     free(values);
+    
+    NSSet *result = [NSSet setWithSet:temp];
     return result;
 }
 


### PR DESCRIPTION
Immutability plays an important role when dealing with concurrency, for this purpose we should ensure that all the operations returns an Immutable Object.

We can discuss about this feature, but IMHO this is the way to go.
